### PR TITLE
[S-1] 사용자는 신규, 인기 카테고리를 선택한 뒤 다른 카테고리도 선택할 수 있다

### DIFF
--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -1,0 +1,38 @@
+import { useMutation } from '@tanstack/react-query';
+import { useDispatch } from 'react-redux';
+
+import useChangeSearchField from '../hooks/useChangeSearchField';
+import { getSearchMeetings } from '../services/api';
+import { setMeetingList } from '../slice';
+
+export default function SearchForm() {
+  const dispatch = useDispatch();
+  const { searchField, handleChangeSearchField, handleClearInputField } = useChangeSearchField();
+
+  const searchMeetings = useMutation({
+    mutationFn: getSearchMeetings,
+    onSuccess: (data) => {
+      alert('검색완료!');
+      dispatch(setMeetingList(data?.data));
+    },
+  });
+
+  const handleClickSearch = (keyword: string) => {
+    keyword ? searchMeetings.mutate(keyword) : alert('검색어를 입력해주세요!');
+    handleClearInputField();
+  };
+
+  return (
+    <div>
+      <input
+        type="text"
+        value={searchField ? searchField : ''}
+        placeholder="검색어 입력..."
+        onChange={(e) => handleChangeSearchField(e)}
+      />
+      <button type="button" onClick={() => handleClickSearch(searchField)}>
+        검색
+      </button>
+    </div>
+  );
+}

--- a/src/components/common/ListCategories.tsx
+++ b/src/components/common/ListCategories.tsx
@@ -5,19 +5,24 @@ import { Link } from 'react-router-dom';
 import { getSortbyMeetings } from '../../services/api';
 import { setMeetingList } from '../../slice';
 
-export default function ListCategories() {
+type ListCategoriesProps = { currSortbyKeyword: string };
+
+export default function ListCategories({ currSortbyKeyword }: ListCategoriesProps) {
   const dispatch = useDispatch();
 
   const sortMeetings = useMutation({
     mutationFn: getSortbyMeetings,
-    onSuccess: (data) => {
-      alert('정렬완료!');
-      dispatch(setMeetingList(data?.data));
+    onSuccess: (data, variables) => {
+      const meetingList = data?.data;
+      const sortbyKeyword = variables;
+      dispatch(setMeetingList({ meetingList, sortbyKeyword }));
     },
   });
 
   const handleClickSortby = (keyword: string) => {
-    sortMeetings.mutate(keyword);
+    currSortbyKeyword === keyword
+      ? alert('같은 카테고리라 서버데이터를 요청하지 않습니다!')
+      : sortMeetings.mutate(keyword);
   };
 
   return (

--- a/src/components/common/TopNavBar.tsx
+++ b/src/components/common/TopNavBar.tsx
@@ -1,45 +1,11 @@
-import { useMutation } from '@tanstack/react-query';
-import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
 
-import useChangeSearchField from '../../hooks/useChangeSearchField';
-import { getSearchMeetings } from '../../services/api';
-import { setMeetingList } from '../../slice';
-
 export default function TopNavBar() {
-  const dispatch = useDispatch();
-  const { searchField, handleChangeSearchField, handleClearInputField } = useChangeSearchField();
-
-  const searchMeetings = useMutation({
-    mutationFn: getSearchMeetings,
-    onSuccess: (data) => {
-      alert('검색완료!');
-      dispatch(setMeetingList(data?.data));
-    },
-  });
-
-  const handleClickSearch = (keyword: string) => {
-    keyword ? searchMeetings.mutate(keyword) : alert('검색어를 입력해주세요!');
-    handleClearInputField();
-  };
-
   return (
-    <div>
+    <>
       <Link to="/">로고</Link>
       <Link to="#">모임 생성</Link>
-      <Link to="#" onClick={() => window.history.back()}>
-        뒤로가기
-      </Link>
-      <input
-        type="text"
-        value={searchField ? searchField : ''}
-        placeholder="검색어 입력..."
-        onChange={(e) => handleChangeSearchField(e)}
-      />
-      <button type="button" onClick={() => handleClickSearch(searchField)}>
-        검색
-      </button>
       <Link to="#">프로필</Link>
-    </div>
+    </>
   );
 }

--- a/src/hooks/useSetMeetingList.ts
+++ b/src/hooks/useSetMeetingList.ts
@@ -1,11 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { getSortbyMeetings } from '../services/api';
 import { setMeetingList } from '../slice';
 
-const DEFAULT_KEYWORD = 'popular';
+const sortbyKeyword = 'popular';
 
 type ReturnType = {
   isLoading: boolean;
@@ -15,14 +14,14 @@ type ReturnType = {
 export default function useSetMeetingList(): ReturnType {
   const dispatch = useDispatch();
 
-  const { isLoading, isError, data } = useQuery({
+  const { isLoading, isError } = useQuery({
     queryKey: ['meetings'],
-    queryFn: () => getSortbyMeetings(DEFAULT_KEYWORD),
+    queryFn: () => getSortbyMeetings(''),
+    onSuccess: (data) => {
+      const meetingList = data?.data;
+      dispatch(setMeetingList({ meetingList, sortbyKeyword }));
+    },
   });
-
-  useEffect(() => {
-    dispatch(setMeetingList(data?.data));
-  }, []);
 
   return {
     isError,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,14 +1,13 @@
 import { useSelector } from 'react-redux';
 
+import SearchForm from '../components/SearchForm';
 import ListCategories from '../components/common/ListCategories';
 import TopNavBar from '../components/common/TopNavBar';
 import useSetMeetingList from '../hooks/useSetMeetingList';
-import { Meeting } from '../types/Meeting';
-
-type AppState = { appReducer: { meetingList: Meeting[] } };
+import { AppState } from '../types/AppTypes';
 
 export default function HomePage() {
-  const { meetingList } = useSelector((state: AppState) => state.appReducer);
+  const { meetingList, sortbyKeyword } = useSelector((state: AppState) => state.appReducer);
   const { isLoading, isError } = useSetMeetingList();
 
   return (
@@ -16,7 +15,8 @@ export default function HomePage() {
       {isLoading ? <div>로딩중 입니다...</div> : null}
       {isError ? <div>에러가 발생...</div> : null}
       <TopNavBar />
-      <ListCategories />
+      <ListCategories currSortbyKeyword={sortbyKeyword} />
+      <SearchForm />
     </>
   );
 }

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -1,18 +1,19 @@
 import { createSlice } from '@reduxjs/toolkit';
 
-import { Meeting } from './types/Meeting';
-
-type AppState = { meetingList: Meeting[] };
+import { InitialState } from './types/AppTypes';
 
 export const app = createSlice({
   name: 'app',
   initialState: {
+    sortbyKeyword: '',
     meetingList: [],
   },
   reducers: {
-    setMeetingList: (state: AppState, { payload }) => {
+    setMeetingList: (state: InitialState, { payload }) => {
+      const { meetingList, sortbyKeyword } = payload;
       return {
-        meetingList: payload,
+        sortbyKeyword,
+        meetingList,
       };
     },
   },

--- a/src/types/AppTypes.ts
+++ b/src/types/AppTypes.ts
@@ -18,3 +18,7 @@ export type Meeting = {
     userProfileImg: string;
   }[];
 };
+
+export type InitialState = { sortbyKeyword: string; meetingList: Meeting[] };
+
+export type AppState = { appReducer: InitialState };


### PR DESCRIPTION
close #6
우선 처음 홈화면이 렌더링될 때 sortby쿼리스트링이 비어있으면 기본으로 인기순 모임 목록가 응답됩니다. 때문에 기본 키워드를 인자값으로 넘기는 대신, 빈문자열을 넘겨줍니다.

그리고 버튼 클릭시 인자값으로 넘어가는 sortby키워드를 스토어 상태객체에 저장하게 로직을 수정했습니다. 스토어 객체의 sort키워드랑 새롭게 인자로 넘겨주는 키워드를 비교해서 같으면 서버에 요청을 하지 않습니다.

그 외에도 type파일을 여러개의 컴포넌트에서 import해서 쓸 수 있게 수정했습니다.