### PR TITLE
[S-2] 신규/인기/검색에 따른 모임목록을 서버데이터 as-is로 구현

### DIFF
--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 
 import useChangeSearchField from '../hooks/useChangeSearchField';
 import { setMeetingList } from '../modules/homeSlice';
-import { getSearchMeetings } from '../services/api';
+import { getSortbyMeetings } from '../services/api';
 import { saveItem } from '../services/storage';
 
 export default function SearchForm() {
@@ -11,7 +11,7 @@ export default function SearchForm() {
   const { searchField, handleChangeSearchField, handleClearInputField } = useChangeSearchField();
 
   const searchMeetings = useMutation({
-    mutationFn: getSearchMeetings,
+    mutationFn: getSortbyMeetings,
     onSuccess: (data, variables) => {
       alert('검색완료!');
 

--- a/src/components/common/ListCategories.tsx
+++ b/src/components/common/ListCategories.tsx
@@ -13,7 +13,6 @@ export default function ListCategories() {
     onSuccess: (data, variables) => {
       variables && saveItem('keyword', variables);
       dispatch(setMeetingList(data));
-      location.reload();
     },
   });
 

--- a/src/hooks/useSetMeetingList.ts
+++ b/src/hooks/useSetMeetingList.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { setMeetingList } from '../modules/homeSlice';
 import { getSortbyMeetings } from '../services/api';
-
-const sortbyKeyword = 'popular';
+import { loadItem } from '../services/storage';
 
 type ReturnType = {
   isLoading: boolean;
@@ -14,14 +14,16 @@ type ReturnType = {
 export default function useSetMeetingList(): ReturnType {
   const dispatch = useDispatch();
 
-  const { isLoading, isError } = useQuery({
+  const sortbyKeyword = loadItem('keyword');
+
+  const { data, isLoading, isError } = useQuery({
     queryKey: ['meetings'],
-    queryFn: () => getSortbyMeetings(''),
-    onSuccess: (data) => {
-      const { meetingList } = data?.data;
-      dispatch(setMeetingList({ meetingList, sortbyKeyword }));
-    },
+    queryFn: () => getSortbyMeetings(sortbyKeyword),
   });
+
+  useEffect(() => {
+    data && dispatch(setMeetingList(data));
+  }, [data?.data.meetingList]);
 
   return {
     isError,

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,5 +1,4 @@
 import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
 
 import Calendar from '../components/Calendar';
 import MeetingList from '../components/MeetingList';
@@ -7,23 +6,23 @@ import SearchForm from '../components/SearchForm';
 import ListCategories from '../components/common/ListCategories';
 import TopNavBar from '../components/common/TopNavBar';
 import useSetMeetingList from '../hooks/useSetMeetingList';
+import { loadItem } from '../services/storage';
 import { AppState } from '../types/AppTypes';
 
 export default function HomePage() {
   const { isLoading, isError } = useSetMeetingList();
-  const { meetingList, sortbyKeyword } = useSelector((state: AppState) => state.home);
+  const sortbyKeyword = loadItem('keyword');
+  const { meetingList } = useSelector((state: AppState) => state.home);
 
   return (
     <>
       {isLoading && <div>로딩중 입니다...</div>}
       {isError && <div>에러가 발생...</div>}
       <TopNavBar />
-      <ListCategories currSortbyKeyword={sortbyKeyword} />
+      <ListCategories />
       <SearchForm />
       {sortbyKeyword === 'calendar' && <Calendar />}
-      {meetingList && meetingList.length !== 0 && (
-        <MeetingList currMeetingList={meetingList} sortbyKeyword={sortbyKeyword} />
-      )}
+      {meetingList && meetingList.length !== 0 && <MeetingList currMeetingList={meetingList} />}
     </>
   );
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { loadItem, saveItem } from './storage';
 
 const baseURL = axios.create({
-  baseURL: 'http://52.79.64.171',
+  baseURL: 'https://sparta-hippo.shop/api',
   headers: {
     'Access-Control-Allow-Origin': '*',
     Authorization: `${loadItem('isLogin')}`,
@@ -14,21 +14,16 @@ const mockURL = axios.create({
   baseURL: 'http://localhost:3003',
 });
 
-const MEETINGS = '/api/meetings';
-const LOGIN = '/api/users/login';
+const MEETINGS = '/meetings';
+const LOGIN = '/users/login';
 
-const MEETINGS_MOCK = '/meetings';
-const NEXT_MOCK = '/next';
+export const getSortbyMeetings = async (keyword: string | null) => {
+  const query =
+    keyword === 'popular' || keyword === 'new'
+      ? `?sortby=${keyword}&category=`
+      : `/search?searchBy=${keyword}&category=`;
 
-export const getSortbyMeetings = async (keyword: string) => {
-  const response = await mockURL.get(MEETINGS_MOCK);
-  // + `?sortby=${keyword}&category=`
-  return response;
-};
-
-export const getSearchMeetings = async (keyword: string) => {
-  const response = await mockURL.get(MEETINGS_MOCK);
-  // + `/search?searchBy=${keyword}&category=`
+  const response = await baseURL.get(MEETINGS + query);
   return response;
 };
 
@@ -52,7 +47,7 @@ export const postLogin = async (userInfo: { email: string; password: string }) =
   });
 
   saveItem('isLogin', response?.headers.authorization as unknown as string);
-  location.reload();
+  location.assign('/main');
 };
 
 export const getDetailPage = async (id: string) => {


### PR DESCRIPTION
issue #27
useQuery에서 반환되는 data를 useEffect훅을 사용하여 페이지가 최초 렌더링될 때 스토어 객체에 저장합니다. 
그리고 mock데이터 대신 서버데이터를 사용하도록 서버 도메인주소를 사용했습니다.
그 외에 getSortbyMeetings, getSearchMeetings api함수를 하나로 합쳤습니다.