### PR TITLE
[S-2] 모임목록 최초 렌더링 로직 수정

### DIFF
--- a/src/components/SearchForm.tsx
+++ b/src/components/SearchForm.tsx
@@ -21,9 +21,17 @@ export default function SearchForm() {
     handleClearInputField();
   };
 
+  const handleEnterKey = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.keyCode == 13) {
+      searchMeetings.mutate(searchField);
+      handleClearInputField();
+    }
+  };
+
   return (
     <div>
       <input
+        onKeyUp={handleEnterKey}
         type="text"
         value={searchField ? searchField : ''}
         placeholder="검색어 입력..."

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -36,9 +36,7 @@ export default function HomePage() {
       <ListCategories />
       <SearchForm />
       {sortbyKeyword === 'calendar' && <Calendar />}
-      {data && data?.data.data.meetingList.length !== 0 && (
-        <MeetingList currMeetingList={meetingList || data?.data.data.meetingList} />
-      )}
+      {meetingList && meetingList.length !== 0 && <MeetingList currMeetingList={meetingList} />}
     </>
   );
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -52,13 +52,17 @@ export const patchJoinMeeting = async (meetingId: number) => {
 };
 
 export const postLogin = async (userInfo: { email: string; password: string }) => {
-  const response = await baseURL.post(LOGIN, userInfo).catch((err) => {
-    alert(err.response.data.statusMsg);
-    location.reload();
-  });
-
-  saveItem('isLogin', response?.headers.authorization as unknown as string);
-  location.assign('/main');
+  await baseURL
+    .post(LOGIN, userInfo)
+    .then((res) => {
+      saveItem('isLogin', res?.headers.authorization as unknown as string);
+      saveItem('keyword', 'popular');
+      location.assign('/main');
+    })
+    .catch((err) => {
+      alert(err.response.data.statusMsg);
+      location.assign('/');
+    });
 };
 
 // id는 number로 넘어가야 하는데 에러


### PR DESCRIPTION
로그인을 실패했을때 화면이 넘어가지 않게 api함수 소스코드를 수정했습니다.

그리고 로그인이 성공했을때 로컬스토리지에 keyword를 popular로 저장해서 모임목록 서버데이터를 요청할 때 쿼리문에 대한 조건식이 제대로 적용되게 고쳤습니다.

그 밖에도 검색어를 입력하고 엔터키를 눌러도 검색이 되게 했습니다.