### PR TITLE
[S-2] 사용자는 '모임에 대해 설명해주세요' 폼을 입력할 수 있다

### DIFF
--- a/src/components/PostContentForm.tsx
+++ b/src/components/PostContentForm.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useParams } from 'react-router-dom';
+
+import useChangePostForm from '../hooks/useChangePostForm';
+import ModalAccordion from './common/ModalAccordion';
+
+export default function PostContentForm() {
+  const [showModal, setShowModal] = useState(false);
+
+  const { id } = useParams();
+
+  const { postForm, handleChangeInputField, handleSubmitForm } = useChangePostForm();
+  const { title, content, category } = postForm;
+
+  const handleClickConfirm = (event: React.ChangeEvent<HTMLFormElement>) => {
+    handleSubmitForm(event);
+    setShowModal(false);
+  };
+
+  return (
+    <>
+      <h2>모임에 대해 설명해주세요!</h2>
+      <label htmlFor="category">주제</label>
+      <button type="button" disabled={id ? true : false} onClick={() => setShowModal(true)}>
+        {category ? category : '주제를 선택해주세요'}
+      </button>
+      {showModal &&
+        createPortal(
+          <ModalAccordion
+            onClickConfirm={handleClickConfirm}
+            onClose={() => setShowModal(false)}
+          />,
+          document.body
+        )}
+      <p>모임 생성 이후 변경이 불가능하니 신중하게 선택해주세요!</p>
+
+      <label htmlFor="title">모임 이름</label>
+      <input
+        type="text"
+        id="title"
+        placeholder="모임 이름을 입력해주세요"
+        value={title}
+        onChange={(e) => handleChangeInputField(e)}
+      />
+
+      <label htmlFor="content">소개</label>
+      <input
+        type="text"
+        id="content"
+        placeholder="최대 20자까지 입력이 가능해요"
+        value={content}
+        onChange={(e) => handleChangeInputField(e)}
+      />
+    </>
+  );
+}

--- a/src/components/common/ModalAccordion.tsx
+++ b/src/components/common/ModalAccordion.tsx
@@ -1,0 +1,32 @@
+import { ModalWrap, Overlay } from '../../styles/ModalFormStyle';
+
+type ModalAccordionProps = {
+  onClickConfirm: (event: React.ChangeEvent<HTMLFormElement>) => void;
+  onClose: () => void;
+};
+
+const options = ['공부하자', '게임하자', '밥먹자', '수다떨자', '술먹자'];
+
+export default function ModalAccordion({ onClickConfirm, onClose }: ModalAccordionProps) {
+  return (
+    <Overlay>
+      <ModalWrap>
+        <button onClick={onClose}>Close</button>
+        <p>모임 주제</p>
+        <form onSubmit={onClickConfirm}>
+          {options.map((option) => {
+            return (
+              <label key={option} htmlFor={option}>
+                <input id={option} type="radio" name="category" value={option} />
+                {option}
+              </label>
+            );
+          })}
+          <button type="submit" disabled={false}>
+            확인
+          </button>
+        </form>
+      </ModalWrap>
+    </Overlay>
+  );
+}

--- a/src/hooks/useChangePostForm.ts
+++ b/src/hooks/useChangePostForm.ts
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+
+import { PostForm } from '../types/AppTypes';
+
+const postFormData: PostForm = {
+  category: '',
+  title: '',
+  content: '',
+  startTime: '',
+  duration: '',
+  platform: '',
+  link: '',
+  maxNum: null,
+  secret: false,
+  secretPassword: null,
+};
+
+export default function useChangePostForm() {
+  const [postForm, setPostForm] = useState(postFormData);
+
+  const handleChangeInputField = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { value, id },
+    } = event;
+    setPostForm({
+      ...postForm,
+      [id]: value,
+    });
+  };
+
+  const handleSubmitForm = (event: React.ChangeEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const { value } = event.target.category;
+
+    setPostForm({
+      ...postForm,
+      category: value,
+    });
+  };
+
+  return {
+    postForm,
+    handleChangeInputField,
+    handleSubmitForm,
+  };
+}

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -1,0 +1,16 @@
+import PostContentForm from '../components/PostContentForm';
+import TopNavBar from '../components/common/TopNavBar';
+
+export default function PostPage() {
+  return (
+    <>
+      <TopNavBar name={'post'} />
+      <br />
+      <br />
+
+      <PostContentForm />
+      <br />
+      <br />
+    </>
+  );
+}

--- a/src/types/AppTypes.ts
+++ b/src/types/AppTypes.ts
@@ -24,3 +24,16 @@ export type InitialState = { meetingList: Meeting[] };
 export type LoginInputField = { email: string; password: string };
 
 export type HomeState = { home: InitialState };
+
+export type PostForm = {
+  title: string;
+  category: string;
+  startTime: string;
+  duration: string;
+  platform: string;
+  link: string;
+  content: string;
+  maxNum: number | null;
+  secret: boolean;
+  secretPassword: number | null;
+};


### PR DESCRIPTION
close #43

<img width="293" alt="스크린샷 2023-01-12 오후 3 26 36" src="https://user-images.githubusercontent.com/89244209/211996083-c6d6aab8-f556-4b64-9376-60af5a511384.png">

위 사진과 같은 부분을 PostContentForm에 구현했습니다.
주제는 ModalAccordion에서 선택하고, 모임이름과 소개는 input창에 입력합니다.

관련된 로직은 useChangePostForm에서 꺼내와서 사용합니다. postForm값에 관련하여 PostForm타입을 추가했습니다.