### PR TITLE
[S-2] 상세페이지 정보탭, 댓글탭에 따라 화면 구성 다르게 하기 

### DIFF
--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -51,26 +51,28 @@ const Comment = () => {
       {isLoading ? <h2>로딩중입니다</h2> : null}
       {isError ? <h2>문제가 생겼습니다</h2> : null}
       <div>
-        {/* {data?.data.map((d: CommentTypes) => { */}
-        {data?.data.data.map((d: CommentTypes) => {
-          return (
-            <CommentBox key={d.commentId}>
-              <img src={d.profileUrl} style={{ width: '30px' }} />
-              <div>
-                <p>{d.username}</p>
-                <p>{d.comment}</p>
-              </div>
-              <p>{d.createdAt}</p>
-              <button
-                onClick={() => {
-                  handleDelComment(d.commentId);
-                }}
-              >
-                삭제
-              </button>
-            </CommentBox>
-          );
-        })}
+        {data?.data.data === undefined
+          ? null
+          : data?.data.data.map((d: CommentTypes) => {
+              return (
+                <CommentBox key={d.commentId}>
+                  <img src={d.profileUrl} style={{ width: '30px' }} />
+                  <div>
+                    <p>{d.username}</p>
+                    <p>{d.comment}</p>
+                  </div>
+                  <p>{d.createdAt}</p>
+                  <button
+                    onClick={() => {
+                      handleDelComment(d.commentId);
+                    }}
+                  >
+                    삭제
+                  </button>
+                </CommentBox>
+              );
+            })}
+
         <InputBox>
           <input
             type="text"

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -10,7 +10,6 @@ import { CommentTypes } from '../types/DetailTypes';
 const Comment = () => {
   const { id } = useParams();
   const QueryClient = useQueryClient();
-
   const [comment, setComment] = useState('');
 
   const { isLoading, data, isError } = useQuery(['Comment', id], () => {
@@ -48,8 +47,8 @@ const Comment = () => {
 
   return (
     <>
-      {isLoading ? <h2>로딩중입니다</h2> : null}
-      {isError ? <h2>문제가 생겼습니다</h2> : null}
+      {/* {isLoading ? <h2>로딩중입니다</h2> : null}
+      {isError ? <h2>문제가 생겼습니다</h2> : null} */}
       <div>
         {data?.data.data === undefined
           ? null

--- a/src/components/KakaoLoginButton.tsx
+++ b/src/components/KakaoLoginButton.tsx
@@ -28,11 +28,9 @@ const kakaoLogin = (code: string | null) => {
       saveItem('username', res.data.data.username);
       saveItem('profileUrl', res.data.data.profileUrl);
       saveItem('keyword', 'popular');
-      console.log(res);
       window.location.href = '/main';
     })
     .catch((err) => {
-      console.log(err);
       window.alert('로그인에 실패하였습니다.');
       window.location.href = '/';
     });

--- a/src/components/common/DetailButton.tsx
+++ b/src/components/common/DetailButton.tsx
@@ -11,8 +11,6 @@ const DetailButton = ({ data }: any) => {
   const [linkInput, setLinkInput] = useState(false);
   const QueryClient = useQueryClient();
 
-  console.log(data);
-
   const useMeetingLinkInput = () => {
     return useMutation(meetingLinkInpitApi, {
       onSuccess: () => {
@@ -38,9 +36,10 @@ const DetailButton = ({ data }: any) => {
     if (data.link) {
       alert(`${data.platform}으로 입장합니다`);
       window.location.href = `/${data.link}`;
-    } else {
-      alert('모임 시작 30분 전부터 입장 가능합니다');
     }
+    // else {
+    //   alert('모임 시작 30분 전부터 입장 가능합니다');
+    // }
   };
 
   return (

--- a/src/components/common/DetailMeetingInfo.tsx
+++ b/src/components/common/DetailMeetingInfo.tsx
@@ -8,8 +8,8 @@ const DetailMeetingInfo = ({ data, isLoading, isError }: any) => {
 
   return (
     <>
-      {isLoading ? <h2>로딩중입니다</h2> : null}
-      {isError ? <h2>문제가 생겼습니다</h2> : null}
+      {/* {isLoading ? <h2>로딩중입니다</h2> : null}
+      {isError ? <h2>문제가 생겼습니다</h2> : null} */}
       <MeetingBox>
         <div className="meeting">
           <img />

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -8,10 +8,10 @@ import DetailButton from '../components/common/DetailButton';
 import DetailMeetingInfo from '../components/common/DetailMeetingInfo';
 import DetailNavBar from '../components/common/DetailNavBar';
 import { getDetailPage } from '../services/api';
-import { useAppSelector } from '../store';
+import { loadItem, saveItem } from '../services/storage';
 
 const DetailPage = () => {
-  const [categories, setCategoreis] = useState('intro');
+  const categories = loadItem('detailKeyword');
 
   const { id } = useParams();
   const { data, isLoading, isError } = useQuery(['detail', id], () => {
@@ -22,13 +22,23 @@ const DetailPage = () => {
   return (
     <div style={{ width: '370px' }}>
       <DetailNavBar data={detailData} />
-
-      {/* <DetailCategories /> */}
+      <button onClick={() => localStorage.getItem('detailKeyword')}>바뀌라</button>
       <div style={{ margin: '15px' }}>
-        <button type="button" onClick={() => setCategoreis('intro')}>
+        <button
+          onClick={() => {
+            saveItem('detailKeyword', 'intro');
+            window.location.reload();
+          }}
+        >
           소개 --- /
         </button>
-        <button type="button" onClick={() => setCategoreis('comment')}>
+
+        <button
+          onClick={() => {
+            saveItem('detailKeyword', 'comment');
+            window.location.reload();
+          }}
+        >
           / ----댓글
         </button>
       </div>


### PR DESCRIPTION
- [ ] close #16 
- useState로 상태변경을 바로 감지해서 소개와 댓글 컴포넌트를 보여주었지만, 새로고침 시 state내용이 유지가 되지 않는 문제가 있었다
- localStorage에 tab키워드를 저장해서 그 값을 통해 해당 컴포넌트를 보여주었다.  
- localStorage는 useState처럼 상태를 바로 변경해주지 않기 때문에 새로고침 코드를 추가하였다