### PR TITLE
[S-2] 모임글 작성/수정완료 서버데이터 as-is로 구현

### DIFF
--- a/src/components/ButtonContent.tsx
+++ b/src/components/ButtonContent.tsx
@@ -1,16 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 
+import { getEditingMeeting } from '../services/api';
 import { Meeting } from '../types/AppTypes';
 import PostButton from './common/PostButton';
 
 export default function ButtonContent({ currMeeting }: { currMeeting: Meeting }) {
   const { master, attend, secret, id } = currMeeting;
 
+  const { refetch } = useQuery({
+    queryKey: ['editingMeeting'],
+    queryFn: () => getEditingMeeting(id),
+    enabled: false,
+  });
+
+  const handleClickEdit = () => {
+    refetch();
+  };
+
   return (
     <>
       {master ? (
         <Link to={`/post/${id}`}>
-          <button type="button">수정버튼</button>
+          <button type="button" onClick={() => handleClickEdit()}>
+            수정버튼
+          </button>
         </Link>
       ) : attend ? (
         <PostButton name={'취소'} currMeeting={currMeeting} />

--- a/src/components/common/ModalAccordionButton.tsx
+++ b/src/components/common/ModalAccordionButton.tsx
@@ -31,10 +31,7 @@ export default function ModalAccordionButton({
               <input
                 type="button"
                 onClick={() => handleShowModal(currModal.name)}
-                value={
-                  value +
-                  (value && name === 'maxNum' ? '명' : value && name === 'duration' ? '시간' : '')
-                }
+                value={value}
                 disabled={(id && name === 'category') || (id && name === 'maxNum') ? true : false}
                 {...register(name, { required: true })}
               />

--- a/src/components/common/TopNavBar.tsx
+++ b/src/components/common/TopNavBar.tsx
@@ -1,12 +1,19 @@
 import { Link } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
 
+import { removeItem } from '../../services/storage';
+
 export default function TopNavBar({ name }: { name: string }) {
   const { id } = useParams();
 
   const handleClickLogout = () => {
     location.assign('/');
     localStorage.clear();
+  };
+
+  const handleClickBack = () => {
+    history.back();
+    removeItem('currPost');
   };
 
   return name === 'home' ? (
@@ -21,7 +28,7 @@ export default function TopNavBar({ name }: { name: string }) {
   ) : name === 'post' ? (
     id ? (
       <>
-        <button type="button" onClick={() => history.back()}>
+        <button type="button" onClick={() => handleClickBack()}>
           {'<'}
         </button>
         <p>모임 수정하기</p>
@@ -31,7 +38,7 @@ export default function TopNavBar({ name }: { name: string }) {
       </>
     ) : (
       <>
-        <button type="button" onClick={() => history.back()}>
+        <button type="button" onClick={() => handleClickBack()}>
           {'<'}
         </button>
         <p>모임 생성하기</p>

--- a/src/pages/PostPage.tsx
+++ b/src/pages/PostPage.tsx
@@ -8,29 +8,42 @@ import ModalAccordionButton from '../components/common/ModalAccordionButton';
 import TopNavBar from '../components/common/TopNavBar';
 import useChangePostForm from '../hooks/useChangePostForm';
 import { editMeeting, postMeeting } from '../services/api';
+import { loadItem } from '../services/storage';
 import { calcStartTime } from '../utils/utils';
 
 export default function PostPage() {
   const { id } = useParams();
 
+  const tmp = loadItem('currPost');
+  const currPost = tmp && JSON.parse(tmp);
+
   const { postForm, handleChangeInputField } = useChangePostForm();
   const { title, content, link } = postForm;
 
-  const { handleSubmit, register, control, setValue } = useForm<FieldValues>({
-    defaultValues: {
-      title: '',
-      category: '',
-      startDate: '',
-      startTime: '',
-      duration: '',
-      platform: '',
-      link: '',
-      content: '',
-      maxNum: '',
-      secret: false,
-      password: '',
-    },
-  });
+  const defaultValues =
+    id && currPost
+      ? currPost
+      : {
+          title: '',
+          category: '',
+          startDate: '',
+          startTime: '',
+          duration: '',
+          platform: '',
+          link: '',
+          content: '',
+          maxNum: '',
+          secret: false,
+          password: '',
+        };
+
+  const {
+    handleSubmit,
+    register,
+    control,
+    setValue,
+    formState: { errors },
+  } = useForm<FieldValues>({ defaultValues });
 
   const mutateEditMeeting = useMutation({
     mutationFn: editMeeting,
@@ -55,13 +68,11 @@ export default function PostPage() {
         <p>모임 생성 이후 변경이 불가능하니 신중하게 선택해주세요!</p>
         <label htmlFor="title">모임 이름</label>
         <input
-          {...register('title', {
-            required: true,
-            maxLength: 20,
-          })}
+          {...register('title', { required: true })}
           type="text"
           id="title"
-          placeholder="모임 이름을 입력해주세요 0/20"
+          maxLength={20}
+          placeholder={currPost ? currPost.title : '모임 이름을 입력해주세요 0/20'}
           value={title}
           onChange={(e) => handleChangeInputField(e)}
         />
@@ -70,7 +81,7 @@ export default function PostPage() {
           {...register('content', { required: true })}
           type="text"
           id="content"
-          placeholder="모두가 즐거운 대화를 나눠요!"
+          placeholder={currPost ? currPost.content : '모두가 즐거운 대화를 나눠요!'}
           value={content}
           onChange={(e) => handleChangeInputField(e)}
         />
@@ -85,7 +96,7 @@ export default function PostPage() {
           {...register('link', { required: false })}
           type="text"
           id="link"
-          placeholder="링크를 입력해주세요"
+          placeholder={currPost ? currPost.link : '링크를 입력해주세요'}
           value={link}
           onChange={(e) => handleChangeInputField(e)}
         />

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
+import { FieldValues } from 'react-hook-form';
 
-import { loadItem, saveItem } from './storage';
+import { loadItem, removeItem, saveItem } from './storage';
 
 const baseURL = axios.create({
   baseURL: 'https://sparta-hippo.shop/api',
@@ -46,6 +47,50 @@ export const patchJoinMeeting = async (meetingId: number) => {
     .then((res) => {
       res.data.data ? alert('참석완!') : alert('취소완!');
       location.reload();
+    })
+    .catch((err) => {
+      alert(err.response.data.statusMsg);
+      location.reload();
+    });
+
+  return response;
+};
+
+export const postMeeting = async (postForm: FieldValues) => {
+  const response = await baseURL
+    .post(MEETINGS, postForm)
+    .then((res) => {
+      res.data.data && alert(res.data.statusMsg);
+      history.back();
+    })
+    .catch((err) => {
+      alert(err.response.data.statusMsg);
+    });
+
+  return response;
+};
+
+export const getEditingMeeting = async (id: number) => {
+  const response = await baseURL
+    .get(MEETINGS + `/${id}/update`)
+    .then((res) => {
+      saveItem('currPost', JSON.stringify(res?.data.data));
+      location.reload();
+    })
+    .catch((err) => {
+      alert(err.response.data.statusMsg);
+    });
+
+  return response;
+};
+
+export const editMeeting = async ({ id, postForm }: { id: number; postForm: FieldValues }) => {
+  const response = await baseURL
+    .patch(MEETINGS + `/${id}`, postForm)
+    .then((res) => {
+      alert(res.data.statusMsg);
+      removeItem('currPost');
+      history.back();
     })
     .catch((err) => {
       alert(err.response.data.statusMsg);


### PR DESCRIPTION
close #67
수정페이지로 갈때 글 수정 페이지 불러오기 데이터를 로컬스토리지에 저장합니다.
수정페이지로 가면 로컬스토리지 가져와서 양식 기본값을 채웁니다.
수정완료 혹은 뒤로가기 버튼을 누르면 로컬스토리지의 양식 기본값 데이터를 삭제합니다.