### PR TITLE
[S-3] Encountered two children with the same key 에러 해결

### DIFF
--- a/src/components/common/Categories.tsx
+++ b/src/components/common/Categories.tsx
@@ -9,7 +9,7 @@ export default function Categories() {
   return (
     <CategoriesWrap>
       {categories?.map((category) => (
-        <Category>
+        <Category key={category}>
           <img src={category_img} />
           <p>{category}</p>
         </Category>

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -36,6 +36,7 @@ export default function useInfiniteScroll(currMeetingList: Meeting[]) {
         const nextMeetingList = data.pages[data.pages.length - 1].data.meetingList;
         dispatch(addMeetingList(nextMeetingList));
       },
+      enabled: false,
     }
   );
 


### PR DESCRIPTION
* useInfiniteScroll훅에 enabled: false옵션을 주어서 스크롤을 움직이지 않아도 서버데이터를 계속 요청하는 것을 고쳤습니다. 
* 그 외에 Categories컴포넌트에 key값을 주어서 에러를 해결했습니다.