### PR TITLE
[S-3] 모임목록의 참석/취소버튼 기능을 수정하라

### DIFF
--- a/src/components/ButtonContent.tsx
+++ b/src/components/ButtonContent.tsx
@@ -28,11 +28,11 @@ export default function ButtonContent({ currMeeting }: { currMeeting: Meeting })
           </PostButtonStyle>
         </Link>
       ) : attend ? (
-        <PostButton name={'취소'} currMeeting={currMeeting} />
+        <PostButton currMeeting={currMeeting} />
       ) : secret ? (
-        <PostButton name={'참여'} currMeeting={currMeeting} />
+        <PostButton currMeeting={currMeeting} />
       ) : (
-        <PostButton name={'참여'} currMeeting={currMeeting} />
+        <PostButton currMeeting={currMeeting} />
       )}
     </>
   );

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -41,10 +41,7 @@ export default function Toggle({
       {showModal &&
         createPortal(
           <ModalForm
-            name={'등록하기'}
             setValue={setValue}
-            password={null}
-            meetingId={null}
             onClickConfirm={null}
             onClose={() => setShowModal(false)}
           />,

--- a/src/components/common/ModalForm.tsx
+++ b/src/components/common/ModalForm.tsx
@@ -1,26 +1,18 @@
+import { useRef } from 'react';
 import { FieldValues, UseFormSetValue } from 'react-hook-form';
 
 import useChangeInputField from '../../hooks/useChangeInputField';
 import { Contents, ModalWrap, Overlay } from '../../styles/ModalFormStyle';
 
 type ModalFormProps = {
-  name: string;
-  password: string | null;
-  meetingId: number | null;
+  setValue: UseFormSetValue<FieldValues>;
   onClose: () => void;
   onClickConfirm: any;
-  setValue: UseFormSetValue<FieldValues>;
 };
 
-export default function ModalForm({
-  name,
-  password,
-  meetingId,
-  onClose,
-  onClickConfirm,
-  setValue,
-}: ModalFormProps) {
+export default function ModalForm({ setValue, onClose, onClickConfirm }: ModalFormProps) {
   const { inputField, handleChangeInputField } = useChangeInputField();
+  const modalRef = useRef(null);
 
   const handleClickConfirm = () => {
     setValue('password', inputField);
@@ -29,21 +21,23 @@ export default function ModalForm({
 
   return (
     <Overlay>
-      <ModalWrap>
+      <ModalWrap ref={modalRef}>
         <label htmlFor="password">비밀번호</label>
         <Contents>
           <input
             id="password"
             type="password"
-            maxLength={4}
             value={inputField}
+            maxLength={4}
             onChange={(e) => handleChangeInputField(e)}
-            placeholder={
-              name === '등록하기' ? '최대 4자까지 입력이 가능해요' : '비밀번호를 입력해주세요'
-            }
+            placeholder={'최대 4자까지 입력이 가능해요'}
           />
           <button onClick={onClose}>취소</button>
-          <button onClick={() => handleClickConfirm()}>{name}</button>
+          <button
+            onClick={() => (onClickConfirm ? onClickConfirm(inputField) : handleClickConfirm())}
+          >
+            {onClickConfirm ? '확인' : '등록하기'}
+          </button>
         </Contents>
       </ModalWrap>
     </Overlay>

--- a/src/components/common/PostButton.tsx
+++ b/src/components/common/PostButton.tsx
@@ -1,40 +1,57 @@
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { useForm } from 'react-hook-form';
+import { FieldValues, useForm } from 'react-hook-form';
 
 import { patchJoinMeeting } from '../../services/api';
 import { PostButtonStyle } from '../../styles/PostButtonStyle';
 import { Meeting } from '../../types/AppTypes';
 import ModalForm from './ModalForm';
 
-export default function PostButton({ name, currMeeting }: { name: string; currMeeting: Meeting }) {
-  const { secret, id, password } = currMeeting;
+export default function PostButton({ currMeeting }: { currMeeting: Meeting }) {
+  const { secret, id, attend, password } = currMeeting;
 
+  const [isAttend, setIsAttend] = useState(attend);
   const [showModal, setShowModal] = useState(false);
 
   const joinMeeting = useMutation({
     mutationFn: patchJoinMeeting,
+    onError: (data: any) => {
+      alert(data.response.data.statusMsg);
+    },
+    onSuccess: (data) => {
+      typeof data.data.data === 'object'
+        ? alert('참석을 완료했습니다.')
+        : alert('모임에서 나왔습니다.');
+      setIsAttend((prev) => !prev);
+    },
   });
 
-  const handleClickJoin = (meetingId: number) => {
-    joinMeeting.mutate(meetingId);
+  const handleClickJoin = (inputField: string | null) => {
+    if (inputField !== null) {
+      if (inputField === password) {
+        joinMeeting.mutate(id);
+        setShowModal(false);
+      } else {
+        alert('비밀번호가 틀렸습니다!');
+      }
+    } else {
+      joinMeeting.mutate(id);
+      setShowModal(false);
+    }
   };
 
-  const { setValue } = useForm();
+  const { setValue } = useForm<FieldValues>();
 
-  return secret ? (
+  return !isAttend && secret ? (
     <>
       <PostButtonStyle type="button" onClick={() => setShowModal(true)}>
-        {name}
+        {!isAttend ? '참여' : '취소'}
       </PostButtonStyle>
       {showModal &&
         createPortal(
           <ModalForm
-            name={name}
             setValue={setValue}
-            password={password}
-            meetingId={id}
             onClickConfirm={handleClickJoin}
             onClose={() => setShowModal(false)}
           />,
@@ -42,8 +59,8 @@ export default function PostButton({ name, currMeeting }: { name: string; currMe
         )}
     </>
   ) : (
-    <PostButtonStyle type="button" onClick={() => handleClickJoin(id)}>
-      {name}
+    <PostButtonStyle type="button" onClick={() => handleClickJoin(null)}>
+      {!isAttend ? '참여' : '취소'}
     </PostButtonStyle>
   );
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -43,17 +43,7 @@ export const getNextMeetings = async ({
 };
 
 export const patchJoinMeeting = async (meetingId: number) => {
-  const response = await baseURL
-    .patch(MEETINGS + `/${meetingId}/attendance`)
-    .then((res) => {
-      res.data.data ? alert('참석완!') : alert('취소완!');
-      location.reload();
-    })
-    .catch((err) => {
-      alert(err.response.data.statusMsg);
-      location.reload();
-    });
-
+  const response = await baseURL.patch(MEETINGS + `/${meetingId}/attendance`);
   return response;
 };
 


### PR DESCRIPTION
close #88
아래와 같이 동작하도록 ModalForm컴포넌트의 로직을 수정했습니다.

* 참석버튼눌렀을 때 정원이 가득차면, 알럿띄우고 새로고침하지 않기
* 비밀방 취소할 땐 모달폼 안떠도 취소되게 하기
* 비밀방 참여 비번틀리면 알럿 후 모달창 유지, 비번맞으면 모달창 끄고 서버요청하기