### PR TITLE
[S-4] 카테고리로 모임목록을 불러와라

### DIFF
--- a/src/components/common/Categories.tsx
+++ b/src/components/common/Categories.tsx
@@ -1,18 +1,53 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
 import category_img from '../../assets/category_img.svg';
-import useShowModalAccordion from '../../hooks/useShowModalAccordion';
-import { CategoriesWrap, Category } from '../../styles/CategoriesStyle';
+import { getSortbyMeetings } from '../../services/api';
+import { loadItem, saveItem } from '../../services/storage';
+import { CategoriesWrap, CategoryButton } from '../../styles/CategoriesStyle';
+
+const buttons = [
+  { name: '수다모여', focus: false },
+  { name: '술모여', focus: false },
+  { name: '밥모여', focus: false },
+  { name: '영화모여', focus: false },
+  { name: '취미모여', focus: false },
+  { name: '공부모여', focus: false },
+  { name: '게임모여', focus: false },
+  { name: '일단모여', focus: false },
+];
 
 export default function Categories() {
-  const { modals } = useShowModalAccordion();
-  const categories = modals.find((modal) => modal.name === 'category')?.options;
+  const queryClient = useQueryClient();
+
+  const sortMeetings = useMutation({
+    mutationFn: getSortbyMeetings,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['meetings'] });
+
+      queryClient.resetQueries({ queryKey: ['nextMeetings'] });
+      queryClient.resetQueries({ queryKey: ['meetings'] });
+    },
+  });
+
+  const handleClickCategory = (category: string) => {
+    saveItem('category', category);
+    sortMeetings.mutate(category);
+  };
 
   return (
     <CategoriesWrap>
-      {categories?.map((category) => (
-        <Category key={category}>
-          <img src={category_img} />
-          <p>{category}</p>
-        </Category>
+      {buttons.map((button) => (
+        <CategoryButton
+          key={button.name}
+          type="button"
+          onClick={() => handleClickCategory(button.name)}
+          focus={button.name === loadItem('category') ? !button.focus : button.focus}
+        >
+          <div>
+            <img src={category_img} />
+            <span>{button.name}</span>
+          </div>
+        </CategoryButton>
       ))}
     </CategoriesWrap>
   );

--- a/src/components/common/SearchForm.tsx
+++ b/src/components/common/SearchForm.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import search_icon from '../../assets/search_icon.svg';
 import useChangeInputField from '../../hooks/useChangeInputField';
@@ -9,22 +9,28 @@ import { InputField, SearchFormWrap } from '../../styles/SearchFormStyle';
 export default function SearchForm() {
   const { inputField, handleChangeInputField, handleClearInputField } = useChangeInputField();
 
+  const queryClient = useQueryClient();
+
   const searchMeetings = useMutation({
     mutationFn: getSortbyMeetings,
     onSuccess: (data, variables) => {
       variables && saveItem('keyword', variables);
-      location.reload();
+      queryClient.invalidateQueries({ queryKey: ['meetings'] });
     },
   });
 
   const handleClickSearch = (keyword: string) => {
-    keyword ? searchMeetings.mutate(keyword) : alert('검색어를 입력해주세요.');
+    if (keyword) {
+      searchMeetings.mutate(keyword);
+    } else {
+      alert('검색어를 입력해주세요.');
+    }
     handleClearInputField();
   };
 
-  const handleEnterKey = (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleEnterKey = (event: React.KeyboardEvent<HTMLInputElement>, keyword: string) => {
     if (event.keyCode == 13) {
-      searchMeetings.mutate(inputField);
+      searchMeetings.mutate(keyword);
       handleClearInputField();
     }
   };
@@ -38,7 +44,7 @@ export default function SearchForm() {
         <input
           type="text"
           placeholder="Search"
-          onKeyUp={handleEnterKey}
+          onKeyUp={(e) => handleEnterKey(e, inputField)}
           value={inputField ? inputField : ''}
           onChange={(e) => handleChangeInputField(e)}
         />

--- a/src/components/common/SortbyCategories.tsx
+++ b/src/components/common/SortbyCategories.tsx
@@ -1,8 +1,8 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { getSortbyMeetings } from '../../services/api';
-import { loadItem, saveItem } from '../../services/storage';
-import { Categories, CategoryButton } from '../../styles/SortbyCategoriesStyle';
+import { loadItem, removeItem, saveItem } from '../../services/storage';
+import { SortbyButton, SortbyWrap } from '../../styles/SortbyCategoriesStyle';
 
 const buttons = [
   { name: '인기모임', focus: false, keyword: 'popular' },
@@ -15,8 +15,8 @@ export default function SortbyCategories() {
 
   const sortMeetings = useMutation({
     mutationFn: getSortbyMeetings,
-    onSuccess: (data, variables) => {
-      variables && saveItem('keyword', variables);
+    onSuccess: () => {
+      saveItem('category', '');
       queryClient.invalidateQueries({ queryKey: ['meetings'] });
 
       queryClient.resetQueries({ queryKey: ['nextMeetings'] });
@@ -24,20 +24,25 @@ export default function SortbyCategories() {
     },
   });
 
+  const handleClickCategory = (keyword: string) => {
+    saveItem('keyword', keyword);
+    sortMeetings.mutate(keyword);
+  };
+
   return (
     <>
-      <Categories>
+      <SortbyWrap>
         {buttons.map((button) => (
-          <CategoryButton
+          <SortbyButton
             key={button.keyword}
             type="button"
-            onClick={() => sortMeetings.mutate(button.keyword)}
+            onClick={() => handleClickCategory(button.keyword)}
             focus={button.keyword === loadItem('keyword') ? !button.focus : button.focus}
           >
             {button.name}
-          </CategoryButton>
+          </SortbyButton>
         ))}
-      </Categories>
+      </SortbyWrap>
     </>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,15 +22,7 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <QueryErrorResetBoundary>
     {({ reset }) => (
-      <ErrorBoundary
-        onReset={reset}
-        fallbackRender={({ resetErrorBoundary }) => (
-          <>
-            <Lottie animationData={error} />
-            <button onClick={() => resetErrorBoundary()}>다시시도</button>
-          </>
-        )}
-      >
+      <ErrorBoundary onReset={reset} fallbackRender={() => <Lottie animationData={error} />}>
         <React.Suspense fallback={<Lottie animationData={loading} />}>
           <QueryClientProvider client={queryClient}>
             <React.StrictMode>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -18,8 +18,8 @@ const LOGIN = '/users/login';
 export const getSortbyMeetings = async (keyword: string | null) => {
   const query =
     keyword === 'popular' || keyword === 'new'
-      ? `?sortby=${keyword}&category=`
-      : `/search?searchBy=${keyword}&category=`;
+      ? `?sortby=${loadItem('keyword')}&category=${loadItem('category')}`
+      : `/search?searchBy=${loadItem('keyword')}&category=${loadItem('category')}`;
 
   const response = await baseURL.get(MEETINGS + query);
   return response;
@@ -29,7 +29,7 @@ export const getNextMeetings = async ({
   meetingId,
   keyword,
 }: {
-  meetingId: number;
+  meetingId: number | false;
   keyword: string | null;
 }) => {
   const query =
@@ -40,11 +40,6 @@ export const getNextMeetings = async ({
   const response = await baseURL.get(MEETINGS + query);
 
   return response.data;
-};
-
-export const patchJoinMeeting = async (meetingId: number) => {
-  const response = await baseURL.patch(MEETINGS + `/${meetingId}/attendance`);
-  return response;
 };
 
 export const postMeeting = async (postForm: FieldValues) => {
@@ -97,6 +92,7 @@ export const postLogin = async (userInfo: { email: string; password: string }) =
     .then((res) => {
       saveItem('isLogin', res?.headers.authorization as unknown as string);
       saveItem('keyword', 'popular');
+      saveItem('category', '');
       saveItem('detailKeyword', 'intro');
       saveItem('userId', res.data.data.id);
       saveItem('username', res.data.data.username);

--- a/src/styles/CategoriesStyle.ts
+++ b/src/styles/CategoriesStyle.ts
@@ -2,25 +2,29 @@ import styled from 'styled-components';
 
 export const CategoriesWrap = styled.div`
   display: flex;
+  justify-content: space-evenly;
+  flex-wrap: wrap;
   padding: 20px 16px;
   background-color: #f9f9f9;
-  overflow-x: scroll;
-  overflow-y: hidden;
-  ::-webkit-scrollbar {
-    display: none;
-  }
 `;
 
-export const Category = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding-right: 20px;
-  & > img {
-    margin-bottom: 8px;
-  }
-  & > p {
-    color: #aaaaaa;
-    font-size: 10px;
+export const CategoryButton = styled.button`
+  background-color: #f9f9f9;
+  & > div {
+    display: flex;
+    flex-direction: column;
+    margin: 0 9px;
+    img {
+      margin-bottom: 8px;
+      border: ${(props: { focus: boolean }) => (props.focus ? '1px solid #FFAB00' : 'none')};
+      box-shadow: ${(props: { focus: boolean }) =>
+        props.focus ? '0px 4px 20px rgba(255, 179, 0, 0.2)' : 'none'};
+      border-radius: 50%;
+    }
+    span {
+      margin-bottom: 16px;
+      color: ${(props: { focus: boolean }) => (props.focus ? '#FFAB00' : '#aaaaaa')};
+      font-size: 10px;
+    }
   }
 `;

--- a/src/styles/MeetingListStyle.ts
+++ b/src/styles/MeetingListStyle.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 export const MeetingListWrap = styled.ul`
   padding: 0 16px;
-  padding-top: 287px;
+  padding-top: 402px;
   padding-bottom: 8px;
   background-color: #f9f9f9;
 `;

--- a/src/styles/SortbyCategoriesStyle.ts
+++ b/src/styles/SortbyCategoriesStyle.ts
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 
-export const Categories = styled.div`
+export const SortbyWrap = styled.div`
   display: flex;
   justify-content: space-evenly;
 `;
 
-export const CategoryButton = styled.button`
+export const SortbyButton = styled.button`
   width: 30%;
   font-size: 16px;
   font-weight: 500;


### PR DESCRIPTION
close #122
* 8가지 카테고리에 따라서 모임목록을 불러올 수 있습니다.
* 그리고 새로고침 대신 쿼리무효화로 모임목록을 업데이트합니다.
* 신규/인기/나의모임 탭을 클릭하면 카테고리는 초기화됩니다.
* 그 외에 카테고리버튼 스타일을 변경했습니다. 슬라이드 대신 고정값입니다.
<img width="375" alt="스크린샷 2023-01-26 오전 12 50 13" src="https://user-images.githubusercontent.com/89244209/214609880-dddce028-eb87-472b-8375-0962bece4357.png">
