### PR TITLE
[S-4] 달력날짜에 해당하는 모임목록을 보여줘라

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "finalProject_FE",
+  "name": "moyeo-FE",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,

--- a/src/components/CalendarList.tsx
+++ b/src/components/CalendarList.tsx
@@ -41,13 +41,17 @@ export default function CalendarList() {
 
   countDownTimer(closeDate, timerRef);
 
+  const meetingList = data?.data.data.meetingList?.filter((obj: { startDate: string }) => {
+    return new Date(obj.startDate).getDate() === startDate.getDate() && obj;
+  });
+
   return (
     <CalendarListWrap>
       <span ref={timerRef}>00:00:00:00</span>
       <CalendarWrap>
         <Calendar attendDates={attendDates} startDate={startDate} setStartDate={setStartDate} />
       </CalendarWrap>
-      <MeetingList currMeetingList={data?.data.data.meetingList} />
+      <MeetingList currMeetingList={meetingList} />
     </CalendarListWrap>
   );
 }

--- a/src/components/MeetingList.tsx
+++ b/src/components/MeetingList.tsx
@@ -18,34 +18,38 @@ export default function MeetingList({ currMeetingList }: ListItemsProps) {
 
   return (
     <MeetingListWrap keyword={loadItem('keyword')}>
-      {currMeetingList.map((meeting) => (
-        <MeetingWrap key={meeting.id}>
-          <ListContent currMeeting={meeting} />
-          {sortbyKeyword === 'calendar' ? null : (
-            <>
-              {meeting.attendantsList && meeting.attendantsList.length !== 0 ? (
-                <AttendantsContent attendantsList={meeting.attendantsList} />
-              ) : (
-                <div></div>
-              )}
-            </>
-          )}
-        </MeetingWrap>
-      ))}
-      {nextMeetingList?.map((meeting) => (
-        <MeetingWrap key={meeting.id}>
-          <ListContent currMeeting={meeting} />
-          {sortbyKeyword === 'calendar' ? null : (
-            <div>
-              {meeting.attendantsList && meeting.attendantsList.length !== 0 ? (
-                <AttendantsContent attendantsList={meeting.attendantsList} />
-              ) : (
-                <div></div>
-              )}
-            </div>
-          )}
-        </MeetingWrap>
-      ))}
+      {currMeetingList.length === 0 ? (
+        <span>참여한 모임이 없어요!</span>
+      ) : (
+        currMeetingList.map((meeting) => (
+          <MeetingWrap key={meeting.id}>
+            <ListContent currMeeting={meeting} />
+            {sortbyKeyword === 'calendar' ? null : (
+              <>
+                {meeting.attendantsList && meeting.attendantsList.length !== 0 ? (
+                  <AttendantsContent attendantsList={meeting.attendantsList} />
+                ) : (
+                  <div></div>
+                )}
+              </>
+            )}
+          </MeetingWrap>
+        ))
+      )}
+      {sortbyKeyword === 'calendar'
+        ? null
+        : nextMeetingList?.map((meeting) => (
+            <MeetingWrap key={meeting.id}>
+              <ListContent currMeeting={meeting} />
+              <>
+                {meeting.attendantsList && meeting.attendantsList.length !== 0 ? (
+                  <AttendantsContent attendantsList={meeting.attendantsList} />
+                ) : (
+                  <div></div>
+                )}
+              </>
+            </MeetingWrap>
+          ))}
       <div ref={intersectRef}></div>
     </MeetingListWrap>
   );

--- a/src/components/common/Calendar.tsx
+++ b/src/components/common/Calendar.tsx
@@ -1,22 +1,24 @@
+import { subMonths } from 'date-fns';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 
 import cal_left_arrow_icon from '../../assets/cal_left_arrow_icon.svg';
 import cal_right_arrow_icon from '../../assets/cal_right_arrow_icon.svg';
+import { loadItem } from '../../services/storage';
 
 export default function Calendar({
   attendDates,
   startDate,
   setStartDate,
 }: {
-  attendDates: any;
+  attendDates: Array<number | undefined>;
   startDate: Date;
   setStartDate: React.Dispatch<React.SetStateAction<Date>>;
 }) {
   return (
     <DatePicker
       inline
-      minDate={new Date()}
+      minDate={loadItem('year') !== null ? subMonths(new Date(), 6) : new Date()}
       selected={startDate}
       onChange={(date: Date) => {
         setStartDate(date);

--- a/src/styles/CalendarListStyle.ts
+++ b/src/styles/CalendarListStyle.ts
@@ -4,6 +4,7 @@ export const CalendarListWrap = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  height: 100vh;
   padding-top: 186px;
   background-color: #fff;
 `;

--- a/src/styles/MeetingListStyle.ts
+++ b/src/styles/MeetingListStyle.ts
@@ -1,11 +1,13 @@
 import styled from 'styled-components';
 
 export const MeetingListWrap = styled.ul`
+  flex-grow: 1;
+  width: 100%;
   padding: 0 16px;
   padding-top: ${(props: { keyword: string | null }) =>
     props.keyword === 'calendar' ? '40px' : '402px'};
   padding-bottom: 8px;
-  border: ${(props: { keyword: string | null }) =>
+  border-top: ${(props: { keyword: string | null }) =>
     props.keyword === 'calendar' ? '1px solid #F4F4F4' : 'none'};
   border-radius: ${(props: { keyword: string | null }) =>
     props.keyword === 'calendar' ? ' 16px 16px 0px 0px' : 'none'};


### PR DESCRIPTION
close #128
* 달력에 선택된 날짜에 해당하는 모임목록을 솔팅하는 로직을 작성했습니다.
* 만약 참여한 목록이 없으면 안내문구가 보입니다.
* 그 외에 Calendar컴포넌트에서 props의 타입을 지정하고, minDate값을 조건적용으로 작성/수정페이지와 다르게 되도록 했습니다. 
* 그리고 화면높이를 채우도록 스타일을 수정했습니다. 결과적으로 아래와 같은 모습입니다.
<img width="376" alt="스크린샷 2023-01-27 오전 1 51 02" src="https://user-images.githubusercontent.com/89244209/214897742-cc9270b7-58ef-436e-8f79-c457ae471ab6.png">
