### PR TITLE
[S-4] 홈페이지의 에러를 고쳐라

### DIFF
--- a/src/components/MeetingList.tsx
+++ b/src/components/MeetingList.tsx
@@ -11,45 +11,35 @@ type ListItemsProps = {
 };
 
 export default function MeetingList({ currMeetingList }: ListItemsProps) {
-  const sortbyKeyword = loadItem('keyword');
-
   const { onIntersect, nextMeetingList } = useInfiniteScroll(currMeetingList);
   const intersectRef = useIntersect(onIntersect);
 
   return (
     <MeetingListWrap keyword={loadItem('keyword')}>
-      {currMeetingList.length === 0 ? (
-        <span>참여한 모임이 없어요!</span>
-      ) : (
-        currMeetingList.map((meeting) => (
-          <MeetingWrap key={meeting.id}>
-            <ListContent currMeeting={meeting} />
-            {sortbyKeyword === 'calendar' ? null : (
-              <>
-                {meeting.attendantsList && meeting.attendantsList.length !== 0 ? (
-                  <AttendantsContent attendantsList={meeting.attendantsList} />
-                ) : (
-                  <div></div>
-                )}
-              </>
+      {currMeetingList.map((meeting) => (
+        <MeetingWrap key={meeting.id}>
+          <ListContent currMeeting={meeting} />
+          <>
+            {meeting.attendantsList && meeting.attendantsList.length !== 0 ? (
+              <AttendantsContent attendantsList={meeting.attendantsList} />
+            ) : (
+              <div></div>
             )}
-          </MeetingWrap>
-        ))
-      )}
-      {sortbyKeyword === 'calendar'
-        ? null
-        : nextMeetingList?.map((meeting) => (
-            <MeetingWrap key={meeting.id}>
-              <ListContent currMeeting={meeting} />
-              <>
-                {meeting.attendantsList && meeting.attendantsList.length !== 0 ? (
-                  <AttendantsContent attendantsList={meeting.attendantsList} />
-                ) : (
-                  <div></div>
-                )}
-              </>
-            </MeetingWrap>
-          ))}
+          </>
+        </MeetingWrap>
+      ))}
+      {nextMeetingList?.map((meeting) => (
+        <MeetingWrap key={meeting.id}>
+          <ListContent currMeeting={meeting} />
+          <>
+            {meeting.attendantsList && meeting.attendantsList.length !== 0 ? (
+              <AttendantsContent attendantsList={meeting.attendantsList} />
+            ) : (
+              <div></div>
+            )}
+          </>
+        </MeetingWrap>
+      ))}
       <div ref={intersectRef}></div>
     </MeetingListWrap>
   );

--- a/src/components/common/SearchForm.tsx
+++ b/src/components/common/SearchForm.tsx
@@ -15,7 +15,11 @@ export default function SearchForm() {
     mutationFn: getSortbyMeetings,
     onSuccess: (data, variables) => {
       variables && saveItem('keyword', variables);
+      saveItem('category', '');
       queryClient.invalidateQueries({ queryKey: ['meetings'] });
+
+      queryClient.resetQueries({ queryKey: ['nextMeetings'] });
+      queryClient.resetQueries({ queryKey: ['meetings'] });
     },
   });
 

--- a/src/components/common/SortbyCategories.tsx
+++ b/src/components/common/SortbyCategories.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { getSortbyMeetings } from '../../services/api';
-import { loadItem, removeItem, saveItem } from '../../services/storage';
+import { loadItem, saveItem } from '../../services/storage';
 import { SortbyButton, SortbyWrap } from '../../styles/SortbyCategoriesStyle';
 
 const buttons = [
@@ -15,7 +15,8 @@ export default function SortbyCategories() {
 
   const sortMeetings = useMutation({
     mutationFn: getSortbyMeetings,
-    onSuccess: () => {
+    onSuccess: (data, variables) => {
+      variables && saveItem('keyword', variables);
       saveItem('category', '');
       queryClient.invalidateQueries({ queryKey: ['meetings'] });
 

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -6,22 +6,28 @@ import { loadItem } from '../services/storage';
 import { Meeting } from '../types/AppTypes';
 
 export default function useInfiniteScroll(currMeetingList: Meeting[]) {
-  const keyword = loadItem('keyword');
-
   const { fetchNextPage, data } = useInfiniteQuery(
     ['nextMeetings'],
-    ({ pageParam = keyword === 'popular' ? 1 : currMeetingList[currMeetingList.length - 1].id }) =>
+    ({
+      pageParam = loadItem('keyword') === 'popular'
+        ? 1
+        : currMeetingList[currMeetingList.length - 1].id,
+    }) =>
       getNextMeetings({
         meetingId: pageParam,
-        keyword,
+        keyword: loadItem('keyword'),
       }),
     {
       getNextPageParam: (lastPage, allPage) => {
         const lastMeetingList = lastPage.data.meetingList;
 
-        return keyword === 'new'
-          ? lastMeetingList[lastMeetingList.length - 1].id
-          : allPage.length + 1;
+        if (lastPage.data.meetingList.length !== 0) {
+          return loadItem('keyword') === 'popular'
+            ? allPage.length + 1
+            : lastMeetingList[lastMeetingList.length - 1].id;
+        } else {
+          return undefined;
+        }
       },
     }
   );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,13 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
+import { useEffect } from 'react';
 
 import CalendarList from '../components/CalendarList';
 import MeetingList from '../components/MeetingList';
 import TopNavBar from '../components/common/TopNavBar';
 import { getSortbyMeetings } from '../services/api';
-import { loadItem } from '../services/storage';
+import { loadItem, saveItem } from '../services/storage';
 
 export default function HomePage() {
-  const sortbyKeyword = loadItem('keyword');
+  useEffect(() => {
+    return () => {
+      saveItem('keyword', 'popular');
+      saveItem('category', '');
+      saveItem('year', '');
+      saveItem('month', '');
+    };
+  }, []);
 
   const { data } = useQuery({
     queryKey: ['meetings'],
@@ -17,8 +25,9 @@ export default function HomePage() {
   return (
     <>
       <TopNavBar name={'home'} />
-      {sortbyKeyword === 'calendar' && <CalendarList />}
-      {data?.data.data.meetingList && data?.data.data.meetingList.length !== 0 && (
+      {loadItem('keyword') === 'calendar' ? (
+        <CalendarList currMeetingList={data?.data.data.meetingList} />
+      ) : (
         <MeetingList currMeetingList={data?.data.data.meetingList} />
       )}
     </>

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -21,14 +21,10 @@ export const getSortbyMeetings = async (keyword: string | null) => {
   const query =
     keyword === 'popular' || keyword === 'new'
       ? `?sortby=${loadItem('keyword')}&category=${loadItem('category')}`
+      : keyword === 'calendar'
+      ? `/mine?year=${loadItem('year')}&month=${loadItem('month')}`
       : `/search?searchBy=${loadItem('keyword')}&category=${loadItem('category')}`;
 
-  const response = await baseURL.get(MEETINGS + query);
-  return response;
-};
-
-export const getMyList = async () => {
-  const query = `/mine?year=${loadItem('year')}&month=${loadItem('month')}`;
   const response = await baseURL.get(MEETINGS + query);
   return response;
 };
@@ -42,11 +38,10 @@ export const getNextMeetings = async ({
 }) => {
   const query =
     keyword === 'popular' || keyword === 'new'
-      ? `?sortby=${keyword}&category=&meetingId=${meetingId}`
-      : `/search?searchBy=${keyword}&category=&meetingId=${meetingId}`;
+      ? `?sortby=${loadItem('keyword')}&category=&meetingId=${meetingId}`
+      : `/search?searchBy=${loadItem('keyword')}&category=&meetingId=${meetingId}`;
 
   const response = await baseURL.get(MEETINGS + query);
-
   return response.data;
 };
 
@@ -104,12 +99,14 @@ export const postLogin = async (userInfo: { email: string; password: string }) =
     .post(LOGIN, userInfo)
     .then((res) => {
       saveItem('isLogin', res?.headers.authorization as unknown as string);
-      saveItem('keyword', 'popular');
-      saveItem('category', '');
       saveItem('detailKeyword', 'intro');
       saveItem('userId', res.data.data.id);
       saveItem('username', res.data.data.username);
       saveItem('profileUrl', res.data.data.profileUrl);
+      saveItem('keyword', 'popular');
+      saveItem('category', '');
+      saveItem('year', '');
+      saveItem('month', '');
       location.assign('/main');
     })
     .catch((err) => {


### PR DESCRIPTION
* 마이페이지 목록을 가져올때도 getSortbyMeetings함수를 사용하게 로직을 수정했습니다. 결과적으로 keyword가 calendar일때 적절한 쿼리문으로 서버데이터를 요청해서 서버오류를 해결했습니다.
* 인기/신규/나의모임 탭이나 검색어로 모임목록을 불러올때 onSuccess로직을 통일했습니다.
* 무한스크롤 로직을 수정해서 TypeError를 해결했습니다.
* HomePage컴포넌트에 클린업 함수로 다른페이지에 갔다오면 홈에 필요한 로컬스토리지의 키워드 처음상태가 되도록 했습니다.