### PR TITLE
[S-4] detail-page height수정 및 페이지 확대시 버튼 사라지는 버그 해결

### DIFF
--- a/src/styles/CommentStyle.ts
+++ b/src/styles/CommentStyle.ts
@@ -1,13 +1,12 @@
 import styled from 'styled-components';
 
 export const CommentBox = styled.div`
-  position: relative;
+  height: 100vh;
+  width: 100%;
   padding: 0 8px;
   box-sizing: border-box;
 `;
 export const CommentViewBox = styled.div`
-  height: 692px;
-  padding-bottom: 36px;
   box-sizing: border-box;
   overflow-y: scroll;
   ::-webkit-scrollbar {
@@ -54,9 +53,9 @@ export const CommentItem = styled.div<{ align: string; bgColor: string }>`
 `;
 export const InputBox = styled.div`
   position: fixed;
-  top: 812px;
-  left: 50%;
-  transform: translate(-50%, -100%);
+  bottom: 0;
+  z-index: 10;
+  width: 359px;
   padding: 16px 0;
   box-sizing: border-box;
   background-color: white;

--- a/src/styles/DetailPageStyle.ts
+++ b/src/styles/DetailPageStyle.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const DetailBox = styled.div`
-  height: 812px;
+  height: 100vh;
   position: relative;
   background-color: white;
   overflow-y: scroll;
@@ -21,8 +21,8 @@ export const DetailBox = styled.div`
   }
   .buttonBox {
     position: fixed;
-    top: 812px;
-    transform: translateY(-100%);
+    bottom: 0;
+    z-index: 10;
     padding: 16px;
     box-sizing: border-box;
     background-color: white;


### PR DESCRIPTION
- height가 고정되어 있어 화면 확대 축소 시,  페이지가 잘려 보이는 style을 100vh로 수정하였습니다.
- 버튼은 fix로 고정시켜 비율에 상관없이 view-port 하단에 붙어있게 하였습니다 