### PR TITLE
[S-5] 회원가입 이메일 인증구현 완성, 비밀번호 변경 페이지 구현

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -84,7 +84,7 @@ const LoginForm = () => {
           <div className="moveText">
             <span
               onClick={() => {
-                navigate('/signup/rewrite');
+                navigate('/repassword');
               }}
             >
               비밀번호 재설정

--- a/src/pages/RePasswordPage.tsx
+++ b/src/pages/RePasswordPage.tsx
@@ -105,82 +105,96 @@ const RePasswordPage = () => {
       <div>
         <p>비밀번호를 잊어버리셨나요?</p>
         <AuthFormBox>
-          <div className="inputBox">
-            <p>이메일 </p>
-            <div className="inputBtnBox">
-              <input
-                type="email"
-                value={email || ''}
-                onChange={(e) => {
-                  setEmail(e.target.value);
-                }}
-                placeholder="이메일 주소를 입력하세요"
-                readOnly={emailAuthCheck ? true : false}
-              />
-              <EmailAuthButton
-                onClick={handleEmailCheck}
-                type="button"
-                disabled={emailAuthCheck ? true : false}
-                disabledStyle={emailAuthCheck ? true : false}
-              >
-                {!emailCheck ? '이메일 인증' : emailAuthCheck ? '인증완료' : '재전송'}
-              </EmailAuthButton>
-            </div>
-            {!emailRegExCheck ? <Label warning={true}>이메일 형식을 확인하세요</Label> : null}
-          </div>
+          {!emailAuthCheck ? (
+            <>
+              <div className="inputBox">
+                <p>이메일 </p>
+                <div className="inputBtnBox">
+                  <input
+                    type="email"
+                    value={email || ''}
+                    onChange={(e) => {
+                      setEmail(e.target.value);
+                    }}
+                    placeholder="이메일 주소를 입력하세요"
+                    readOnly={emailAuthCheck ? true : false}
+                  />
+                  <EmailAuthButton
+                    onClick={handleEmailCheck}
+                    type="button"
+                    disabled={emailAuthCheck ? true : false}
+                    disabledStyle={emailAuthCheck ? true : false}
+                  >
+                    {!emailCheck ? '이메일 인증' : emailAuthCheck ? '인증완료' : '재전송'}
+                  </EmailAuthButton>
+                </div>
+                {!emailRegExCheck ? <Label warning={true}>이메일 형식을 확인하세요</Label> : null}
+              </div>
+              <div className="inputBox">
+                <div className="inputBtnBox">
+                  <input
+                    type="text"
+                    placeholder="인증번호를 입력하세요"
+                    onChange={(e) => {
+                      setAuthNumber(e.target.value);
+                    }}
+                    readOnly={emailAuthCheck ? true : false}
+                  />
+                  <EmailAuthButton
+                    onClick={handleClickEamilAuth}
+                    type="button"
+                    disabled={emailAuthCheck ? true : false}
+                    disabledStyle={emailAuthCheck ? true : false}
+                  >
+                    {emailAuthCheck ? '인증완료' : '인증하기'}
+                  </EmailAuthButton>
+                </div>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="inputBox">
+                <p>비밀번호 </p>
+                <input
+                  type="password"
+                  value={password || ''}
+                  onChange={(e) => {
+                    setPassword(e.target.value);
+                  }}
+                  placeholder="비밀번호를 작성해 주세요"
+                />
+                <Label warning={passwordRegExCheck ? false : true}>
+                  영어 대소문자, 숫자, 특수문자를 포함한 8-16자를 입력하세요
+                </Label>
+              </div>
 
-          <div className="inputBox">
-            <div className="inputBtnBox">
-              <input
-                type="text"
-                placeholder="인증번호를 입력하세요"
-                onChange={(e) => {
-                  setAuthNumber(e.target.value);
-                }}
-                readOnly={emailAuthCheck ? true : false}
-              />
-              <EmailAuthButton
-                onClick={handleClickEamilAuth}
-                type="button"
-                disabled={emailAuthCheck ? true : false}
-                disabledStyle={emailAuthCheck ? true : false}
-              >
-                {emailAuthCheck ? '인증완료' : '인증하기'}
-              </EmailAuthButton>
-            </div>
-          </div>
-
-          <div className="inputBox">
-            <p>비밀번호 </p>
-            <input
-              type="password"
-              value={password || ''}
-              onChange={(e) => {
-                setPassword(e.target.value);
-              }}
-              placeholder="비밀번호를 작성해 주세요"
-            />
-            <Label warning={passwordRegExCheck ? false : true}>
-              영어 대소문자, 숫자, 특수문자를 포함한 8-16자를 입력하세요
-            </Label>
-          </div>
-
-          <div className="inputBox">
-            <p>비밀번호 재확인 </p>
-            <input
-              type="password"
-              value={passwordCheck || ''}
-              onChange={(e) => {
-                setPasswordCheck(e.target.value);
-              }}
-              placeholder="비밀번호를 확인 주세요"
-            />
-            <Label warning={passwordDoubleCheck ? false : true}>동일한 비밀번호를 입력하세요</Label>
-          </div>
+              <div className="inputBox">
+                <p>비밀번호 재확인 </p>
+                <input
+                  type="password"
+                  value={passwordCheck || ''}
+                  onChange={(e) => {
+                    setPasswordCheck(e.target.value);
+                  }}
+                  placeholder="비밀번호를 확인 주세요"
+                />
+                <Label warning={passwordDoubleCheck ? false : true}>
+                  동일한 비밀번호를 입력하세요
+                </Label>
+              </div>
+            </>
+          )}
         </AuthFormBox>
-        <AuthButtonBox>
-          <button onClick={handleClickRepassword}>비밀번호 바꾸기</button>
-        </AuthButtonBox>
+        {!emailAuthCheck ? null : (
+          <AuthButtonBox>
+            <button
+              style={{ backgroundColor: '#ffb300', color: 'white' }}
+              onClick={handleClickRepassword}
+            >
+              비밀번호 변경
+            </button>
+          </AuthButtonBox>
+        )}
       </div>
     </SignupBox>
   );

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -123,7 +123,7 @@ const SignupPage = () => {
     if (!usernameValueCheck) {
       setUsernameRegExCheck(false);
     }
-    postSignup({ email, password, username });
+    postSignup({ email, password, username })
   };
 
   const goLogin = () => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -150,28 +150,39 @@ export const postLogin = async (userInfo: { email: string; password: string }) =
 
 export const emailCheckApi = async (email: string) => {
   const res = await baseURL.get(`/users/mail-code/create?email=${email}`);
-  console.log(res);
   return res;
 };
 
 export const emailAuthNumberApi = async ({ email, authNumber }: EmailAuthType) => {
-  const res = await baseURL.post(`/users/mail-code/confirm?&ePw=${authNumber}`, {
-    email,
-    authNumber,
+  const res = await baseURL.post('/users/mail-code/confirm', {
+    email: email,
+    ePw: authNumber,
   });
-  // // post요청하면 email에러 안뜨는데.  get과 post차이가 있나
-  // console.log(res);
-  // return res;
+  return res;
 };
 
 export const signupApi = async ({ email, password, username }: SignUp) => {
-  const res = await baseURL.post('/users/signup', { email, password, username });
-  return res;
+  const res = await baseURL
+    .post('/users/signup', { email, password, username })
+    .then((res) => {
+      toast('회원가입 성공');
+      location.replace('/');
+    })
+    .catch((err) => {
+      toast(err.response.data.statusMsg);
+    });
 };
 
 export const rePasswordApi = async ({ email, password }: RePasswordType) => {
-  const res = await baseURL.patch('/users/password', { email, password });
-  return res;
+  const res = await baseURL
+    .patch('/users/passwordChange', { email, password })
+    .then((res) => {
+      location.replace('/');
+      toast('비밀번호 변경 성공');
+    })
+    .catch((err) => {
+      toast(err.response.data.statusMsg);
+    });
 };
 
 export const getDetailPage = async (id: string | undefined) => {


### PR DESCRIPTION
- 이메일 인증 -> 메일로 인증번호 보내지면 인증번호까지 인증 한 후 회원가입 진행되록 함
- 기본 알럿은 toast로 바꾸었고, 정규식에 맞지 않는 경우 인풋창 아래 경고문구가 뜨도록 구현하였다
- 비밀번호 변경 페이지 구현 
